### PR TITLE
ci: migrate GCP auth to keyless Workload Identity Federation (WIF)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,9 +7,10 @@ on:
         type: boolean
         required: true
         default: false
-    secrets:
-      credentials_json:
+      beta:
+        type: boolean
         required: false
+        default: false
 
 jobs:
   build:
@@ -97,6 +98,9 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+    permissions:
+      id-token: write   # required for keyless WIF (OIDC) auth to GCP
+      contents: write   # required for softprops/action-gh-release
     steps:
 
       ### Pulling down the previously built plugins
@@ -114,17 +118,19 @@ jobs:
       - name: List
         run: ls -la
 
-      ### Authenticating with gcloud
-      - name: Authenticate with Google cloud
-        uses: google-github-actions/auth@v2
+      ### Authenticating with gcloud via keyless Workload Identity Federation (OIDC)
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v3
         with:
-          credentials_json: ${{ secrets.credentials_json }}
-          project_id: ${{ inputs.project_id }}
+          workload_identity_provider: projects/497784144587/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+          service_account: github-actions@integration-server-326115.iam.gserviceaccount.com
           create_credentials_file: true
 
       ### Setting up gcloud cli
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v2'
+        with:
+          project_id: integration-server-326115
 
       ### Verifying that we are good to go with gcloud
       - name: 'Use gcloud CLI'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,8 +7,9 @@ on:
 
 jobs:
   build:
+    permissions:
+      id-token: write   # required so the reusable workflow can mint a GCP OIDC token
+      contents: write   # required for GitHub release creation in the reusable workflow
     uses: ./.github/workflows/build.yaml
     with:
       deploy: true
-    secrets:
-      credentials_json: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -7,8 +7,9 @@ on:
 
 jobs:
   build:
+    permissions:
+      id-token: write   # required so the reusable workflow can mint a GCP OIDC token
+      contents: write   # required for GitHub release creation in the reusable workflow
     uses: ./.github/workflows/build.yaml
     with:
       deploy: false
-    secrets:
-      credentials_json: ${{ secrets.GCP_CREDENTIALS }}


### PR DESCRIPTION
## Summary

The static `GCP_CREDENTIALS` service-account key (SA `github-actions@integration-server-326115`, project `integration-server-326115` / `#497784144587`) was **deleted** during weekend incident remediation, which **broke** the GCS upload in the release/staging pipeline (`push-build` job). This PR migrates CI to **keyless Workload Identity Federation (OIDC)** so no static key is needed, mirroring the `builds_server` #19/#20 pattern.

## Changes

- **`build.yaml`** (`push-build` job):
  - `google-github-actions/auth@v2` + `credentials_json` ➜ `auth@v3` keyless WIF (`workload_identity_provider` + `service_account`, `create_credentials_file: true`).
  - `setup-gcloud@v2` now pins `project_id: integration-server-326115` (replacing the dropped, **undeclared** `inputs.project_id`).
  - Added job `permissions: { id-token: write, contents: write }` (`id-token` for OIDC, `contents` for `softprops/action-gh-release`).
- **`release.yaml` / `staging.yaml`** (callers of the reusable workflow):
  - Granted `permissions: { id-token: write, contents: write }` on the calling job so the reusable workflow can mint the OIDC token.
  - Removed the now-unused `secrets.credentials_json: ${{ secrets.GCP_CREDENTIALS }}` passthrough.
- **`build.yaml`** (`workflow_call`): declared the previously-**undeclared** `beta` input (`type: boolean`, default `false`); removed the `credentials_json` secret declaration.

## GCP infra (verified, not modified)

- WIF binding for `pieces-app/plugin_sublime` ➜ `roles/iam.workloadIdentityUser` on `github-actions@integration-server-326115` is **already present** (verified via `get-iam-policy`, not recreated).
- Provider: `projects/497784144587/locations/global/workloadIdentityPools/github-pool/providers/github-provider`.
- Buckets `app-releases-production` / `app-releases-staging` are in the standard allowlist (`app-releases-*`) — no additional bucket-scoped grant required.
- No chained impersonation; gsutil-only (no `gcloud run deploy`) ➜ no runtime SA required. No IAM writes performed.

## Test plan

- [ ] **Do not merge** until a manual validation run is green.
- [ ] Push to `main` triggers `Staging` ➜ confirm `push-build` authenticates via WIF and `gsutil cp` to `gs://app-releases-staging/...` succeeds.
- [ ] Tag push (`*.*.*`) triggers `Release` ➜ confirm WIF auth + `gsutil cp` to `gs://app-releases-production/...` and GitHub Release creation succeed.

## Notes / follow-ups

- The `GCP_CREDENTIALS` GitHub secret is left in place (now unused); safe to delete after validation.
- Latent (pre-existing, out of scope): `secrets.PERSONAL_ACCESS_TOKEN` in the `build` job is referenced but not declared in `workflow_call.secrets` nor inherited, so it resolves empty on the version-mismatch error path.

Made with [Cursor](https://cursor.com)